### PR TITLE
Fixup issues from testing

### DIFF
--- a/lib/msf/core/constants.rb
+++ b/lib/msf/core/constants.rb
@@ -108,7 +108,7 @@ module HttpClients
   CHROME = "Chrome"
   EDGE = "Edge"
   GIT = "Git"
-  GITLFS = "Git LFS"
+  GIT_LFS = "Git LFS"
 
   UNKNOWN = "Unknown"
 end

--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -274,6 +274,12 @@ module Exploit::Remote::HttpServer
       when /mozilla\/[0-9]+\.[0-9] \(compatible; msie ([0-9]+\.[0-9]+)/i, /mozilla\/[0-9]+\.[0-9] \(.+ rv:([0-9]+\.[0-9])\)/i
         fp[:ua_name] = HttpClients::IE
         fp[:ua_ver] = $1
+      when /git\/([0-9]+(\.[0-9]+)+)/
+        fp[:ua_name] = HttpClients::GIT
+        fp[:ua_ver] = $1
+      when /git-lfs\/([0-9]+(\.[0-9]+)+)/
+        fp[:ua_name] = HttpClients::GIT_LFS
+        fp[:ua_ver] = $1
       else
         fp[:ua_name] = HttpClients::UNKNOWN
     end

--- a/modules/exploits/windows/http/git_lfs_rce.rb
+++ b/modules/exploits/windows/http/git_lfs_rce.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Git
   include Msf::Exploit::Git::Lfs
   include Msf::Exploit::Git::SmartHttp
@@ -65,6 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('GIT_URI', [ false, 'The URI to use as the malicious Git instance (empty for random)', '' ])
     ])
+    deregister_options('RHOSTS')
   end
 
   def setup_repo_structure
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if info[:os_name] == 'Windows' &&
        ((info[:ua_name] == Msf::HttpClients::GIT && Rex::Version.new(info[:ua_ver]) <= Rex::Version.new('2.29.2')) ||
-         (info[:ua_name] == Msf::HttpClients::GITLFS && Rex::Version.new(info[:ua_ver]) <= Rex::Version.new('2.12')))
+         (info[:ua_name] == Msf::HttpClients::GIT_LFS && Rex::Version.new(info[:ua_ver]) <= Rex::Version.new('2.12')))
       true
     else
       fail_with(Failure::NotVulnerable, "The git client needs to be running on Windows with a version equal or less than 2.29.2 while git-lfs needs to be equal or less than 2.12.0. The user agent, #{info[:ua_name]}, found was running on, #{info[:os_name]} and was at version: #{info[:ua_ver]}")
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def handle_lfs_objects(req, hook_payload, git_addr)
-    git_hook_obj = Msf::Exploit::Git::Lfs::GitObject.build_blob_object(hook_payload)
+    git_hook_obj = GitObject.build_blob_object(hook_payload)
 
     case req.method
     when 'POST'


### PR DESCRIPTION
This fixes up the issues I noticed while testing rapid7/metasploit-framework#15624.

I added in parsing for the new Git and Git LFS user agents which I'm guessing was lost in a rebase. I also deregistered RHOSTS, removed an unnecessary mixin, and fixed a name error.