### PR TITLE
Fix for Suite CRM export sqli

### DIFF
--- a/lib/msf/core/exploit/sqli/boolean_based_blind_mixin.rb
+++ b/lib/msf/core/exploit/sqli/boolean_based_blind_mixin.rb
@@ -42,7 +42,7 @@ module Msf::Exploit::SQLi
     # @return [Object] should return a true value if the query returned a result, false or nil otherwise
     #
     def blind_request(query)
-      @query_proc.call('1=2')
+      @query_proc.call(query)
     end
   end
 end


### PR DESCRIPTION
This pull-request aims to fix the SQL injection module.

- Makes use of the SQL injection library that is integrated in metasploit.

Only use `run_sql` (as other methods might include commas in their payload). And use `to_base64` if the response could include underscores or percentage signs.