### PR TITLE
Option Edge Case Handling For BadSuccessor

### DIFF
--- a/modules/auxiliary/admin/ldap/bad_successor.rb
+++ b/modules/auxiliary/admin/ldap/bad_successor.rb
@@ -125,9 +125,13 @@ class MetasploitModule < Msf::Auxiliary
       Exploit::CheckCode::Appears
     end
   rescue Errno::ECONNRESET
-    return Exploit::CheckCode::Unknown('The connection was reset')
-  rescue Rex::ConnectionError, Net::LDAP::Error => e
-    return Exploit::CheckCode::Unknown(e.message)
+    fail_with(Failure::Disconnected, 'The connection was reset.')
+  rescue Rex::ConnectionError => e
+    fail_with(Failure::Unreachable, e.message)
+  rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
+    fail_with(Failure::NoAccess, e.message)
+  rescue Net::LDAP::Error => e
+    fail_with(Failure::Unknown, "#{e.class}: #{e.message}")
   end
 
   def get_ous_we_can_write_to
@@ -174,7 +178,7 @@ class MetasploitModule < Msf::Auxiliary
     sam_account_name = account_name
     sam_account_name += '$' unless sam_account_name.ends_with?('$')
     dn = "CN=#{account_name},#{writeable_dn}"
-    print_status("Attempting to create dmsa account cn: #{account_name}, dn: #{dn}")
+    print_status("Attempting to create dMSA account CN: #{account_name}, DN: #{dn}")
 
     dmsa_attributes = {
       'objectclass' => ['top', 'person', 'organizationalPerson', 'user', 'computer', 'msDS-DelegatedManagedServiceAccount'],


### PR DESCRIPTION
This adds some edge case handling for BadSuccessor datastore options

* Now the `datastore['LDAPDomain']` can also be the NETBios short name, e.g. `MSFLAB` instead of the full domain name, (`msflab.local`). LDAP can auth just fine with the NETBios name, so it'll fetch the DNS name for the fields that require the actual domain name.
* Validates that the LDAP authentication options are ones that use passwords. SCHANNEL and kerberos won't work because of how the LDAPPassword option is required for get_ticket.
* Validates that the LDAPPassword is not an NTLM hash when it needs to be used by get_ticket which isn't compatible with pass-the-hash.